### PR TITLE
[남기]Feat: orderDetail 생성 조회 기능구현

### DIFF
--- a/jascoffee/src/main/java/com/jascoffee/jascoffee/config/user/SecurityConfig.java
+++ b/jascoffee/src/main/java/com/jascoffee/jascoffee/config/user/SecurityConfig.java
@@ -62,9 +62,10 @@ public class SecurityConfig{
 
         http
                 .authorizeHttpRequests((auth)-> auth
-                        .requestMatchers("/login","/","/join").permitAll()
+                        .requestMatchers("/login","/","/join","/products","/orderdetail","api/orderlist","orderdetailAll").permitAll()
                         .requestMatchers("/reissue").permitAll()
                         .requestMatchers("/admin").hasRole("ADMIN")
+                        .requestMatchers("/users/change-password").authenticated()
                         .anyRequest().authenticated());
         http
                 .addFilterBefore(new JWTFilter(jwtUtil), LoginFilter.class);

--- a/jascoffee/src/main/java/com/jascoffee/jascoffee/controller/orderlist/OrderDetailController.java
+++ b/jascoffee/src/main/java/com/jascoffee/jascoffee/controller/orderlist/OrderDetailController.java
@@ -1,4 +1,41 @@
 package com.jascoffee.jascoffee.controller.orderlist;
 
+
+import com.jascoffee.jascoffee.dto.orderlist.request.OrderDetailCreateRequest;
+import com.jascoffee.jascoffee.dto.orderlist.response.OrderDetailResponse;
+import com.jascoffee.jascoffee.entity.orderlist.OrderDetailEntity;
+import com.jascoffee.jascoffee.service.orderlist.OrderDetailService;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
 public class OrderDetailController {
+    private OrderDetailService orderDetailService;
+
+    public OrderDetailController(OrderDetailService orderDetailService){
+        this.orderDetailService = orderDetailService;
+    }
+    @PostMapping("/orderdetail")
+    public void saveOrderDetail(@RequestBody OrderDetailCreateRequest request) {
+        orderDetailService.saveOrderDetail(request);
+    }
+
+    @GetMapping("/orderdetailAll")
+    public List<OrderDetailResponse> getOrderDetails() {
+        return orderDetailService.getOrderDetails();
+    }
+
+//    @GetMapping("/orderdetail")
+//    public List<OrderDetailResponse> getOrderDetail(){
+//        return orderDetailService.getOrderDetail();
+//    }
+
+
+//    @DeleteMapping("/orderdetails/{detailID}")
+//    public void deleteOrderDetail(@PathVariable Long detailID) {
+//        orderDetailService.deleteOrderDetail(detailID);
+//    }
+
+
 }

--- a/jascoffee/src/main/java/com/jascoffee/jascoffee/controller/orderlist/OrderDetailController.java
+++ b/jascoffee/src/main/java/com/jascoffee/jascoffee/controller/orderlist/OrderDetailController.java
@@ -26,10 +26,10 @@ public class OrderDetailController {
         return orderDetailService.getOrderDetails();
     }
 
-//    @GetMapping("/orderdetail")
-//    public List<OrderDetailResponse> getOrderDetail(){
-//        return orderDetailService.getOrderDetail();
-//    }
+    @GetMapping("/orderdetail")
+    public List<OrderDetailResponse> getOrderDetail(@RequestParam Long id){
+        return orderDetailService.getOrderDetailByorderDetailID(id);
+    }
 
 
 //    @DeleteMapping("/orderdetails/{detailID}")

--- a/jascoffee/src/main/java/com/jascoffee/jascoffee/dto/orderlist/request/OrderDetailCreateRequest.java
+++ b/jascoffee/src/main/java/com/jascoffee/jascoffee/dto/orderlist/request/OrderDetailCreateRequest.java
@@ -1,4 +1,62 @@
 package com.jascoffee.jascoffee.dto.orderlist.request;
 
+
 public class OrderDetailCreateRequest {
+    private Long orderID;            // OrderListEntity ID
+    private Long productID;          // ProductEntity ID
+    private Boolean isIce;
+    private Integer shot;
+    private Integer pearl;
+    private Integer milk;
+    private Integer syrup;
+    private Integer vanillaSyrup;    // DTO에서는 camelCase 사용
+    private Integer hazelnutSyrup;
+    private Boolean isWhip;
+    private Integer price;
+
+    public  OrderDetailCreateRequest(){}
+
+    public Long getOrderID() {
+        return orderID;
+    }
+
+    public Long getProductID() {
+        return productID;
+    }
+
+    public Boolean getIsIce() {
+        return isIce;
+    }
+
+    public Integer getShot() {
+        return shot;
+    }
+
+    public Integer getPearl() {
+        return pearl;
+    }
+
+    public Integer getMilk() {
+        return milk;
+    }
+
+    public Integer getSyrup() {
+        return syrup;
+    }
+
+    public Integer getVanillaSyrup() {
+        return vanillaSyrup;
+    }
+
+    public Integer getHazelnutSyrup() {
+        return hazelnutSyrup;
+    }
+
+    public Boolean getIsWhip() {
+        return isWhip;
+    }
+
+    public Integer getPrice() {
+        return price;
+    }
 }

--- a/jascoffee/src/main/java/com/jascoffee/jascoffee/dto/orderlist/response/OrderDetailResponse.java
+++ b/jascoffee/src/main/java/com/jascoffee/jascoffee/dto/orderlist/response/OrderDetailResponse.java
@@ -32,5 +32,7 @@ public class OrderDetailResponse {
         this.isWhip = detail.getIsWhip();
         this.price = detail.getPrice();
     }
-//    public OrderDetailResponse(Long orderDetailID, Long orderID)
+    public OrderDetailResponse(Long orderDetailID){
+        this.orderDetailID = orderDetailID;
+    }
 }

--- a/jascoffee/src/main/java/com/jascoffee/jascoffee/dto/orderlist/response/OrderDetailResponse.java
+++ b/jascoffee/src/main/java/com/jascoffee/jascoffee/dto/orderlist/response/OrderDetailResponse.java
@@ -1,4 +1,36 @@
 package com.jascoffee.jascoffee.dto.orderlist.response;
 
+import com.jascoffee.jascoffee.entity.orderlist.OrderDetailEntity;
+import lombok.Getter;
+
+@Getter
 public class OrderDetailResponse {
+    private Long orderDetailID;
+    private Long orderID;
+    private Long productID;
+    private Boolean isIce;
+    private Integer shot;
+    private Integer pearl;
+    private Integer milk;
+    private Integer syrup;
+    private Integer vanillaSyrup;
+    private Integer hazelnutSyrup;
+    private Boolean isWhip;
+    private Integer price;
+
+    public OrderDetailResponse(OrderDetailEntity detail) {
+        this.orderDetailID = detail.getOrderDetailID();
+        this.orderID = detail.getOrderlist().getOrderID();
+        this.productID = detail.getProduct().getProductId();
+        this.isIce = detail.getIsIce();
+        this.shot = detail.getShot();
+        this.pearl = detail.getPearl();
+        this.milk = detail.getMilk();
+        this.syrup = detail.getSyrup();
+        this.vanillaSyrup = detail.getVanilaSyrup();
+        this.hazelnutSyrup = detail.getHazelnutSyrup();
+        this.isWhip = detail.getIsWhip();
+        this.price = detail.getPrice();
+    }
+//    public OrderDetailResponse(Long orderDetailID, Long orderID)
 }

--- a/jascoffee/src/main/java/com/jascoffee/jascoffee/entity/orderlist/OrderDetailEntity.java
+++ b/jascoffee/src/main/java/com/jascoffee/jascoffee/entity/orderlist/OrderDetailEntity.java
@@ -1,4 +1,132 @@
 package com.jascoffee.jascoffee.entity.orderlist;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.jascoffee.jascoffee.entity.product.Product;
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "orderdetail")
 public class OrderDetailEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long orderDetailID;
+
+    @ManyToOne
+    @JoinColumn(name = "orderID", nullable = false, referencedColumnName = "orderID")
+    private OrderListEntity orderlist;
+
+    @ManyToOne
+    @JoinColumn(name = "productID", nullable = false, referencedColumnName = "productID")
+    private Product product;
+
+    @JsonProperty("isIce")
+    private Boolean isIce;
+    @JsonProperty("shot")
+    private Integer shot;
+    @JsonProperty("pearl")
+    private Integer pearl;
+    @JsonProperty("milk")
+    private Integer milk;
+    @JsonProperty("syrup")
+    private Integer syrup;
+    @JsonProperty("vanilaSyrup")
+    private Integer vanilaSyrup;
+    @JsonProperty("hazelnutSyrup")
+    private Integer hazelnutSyrup;
+    @JsonProperty("isWhip")
+    private Boolean isWhip;
+    @JsonProperty("price")
+    private Integer price;
+
+    public void setOrderlist(OrderListEntity orderlist) {
+        this.orderlist = orderlist;
+    }
+
+    public void setProduct(Product product) {
+        this.product = product;
+    }
+
+    public void setIsIce(Boolean ice) {
+        isIce = ice;
+    }
+
+    public void setShot(Integer shot) {
+        this.shot = shot;
+    }
+
+    public void setPearl(Integer pearl) {
+        this.pearl = pearl;
+    }
+
+    public void setMilk(Integer milk) {
+        this.milk = milk;
+    }
+
+    public void setSyrup(Integer syrup) {
+        this.syrup = syrup;
+    }
+
+    public void setVanilaSyrup(Integer vanilaSyrup) {
+        this.vanilaSyrup = vanilaSyrup;
+    }
+
+    public void setHazelnutSyrup(Integer hazelnutSyrup) {
+        this.hazelnutSyrup = hazelnutSyrup;
+    }
+
+    public void setIsWhip(Boolean whip) {
+        isWhip = whip;
+    }
+
+    public void setPrice(Integer price) {
+        this.price = price;
+    }
+
+    public Long getOrderDetailID() {
+        return orderDetailID;
+    }
+
+    public OrderListEntity getOrderlist() {
+        return orderlist;
+    }
+
+    public Product getProduct() {
+        return product;
+    }
+
+    public Boolean getIsIce() {
+        return isIce;
+    }
+
+    public Integer getShot() {
+        return shot;
+    }
+
+    public Integer getPearl() {
+        return pearl;
+    }
+
+    public Integer getMilk() {
+        return milk;
+    }
+
+    public Integer getSyrup() {
+        return syrup;
+    }
+
+    public Integer getVanilaSyrup() {
+        return vanilaSyrup;
+    }
+
+    public Integer getHazelnutSyrup() {
+        return hazelnutSyrup;
+    }
+
+    public Boolean getIsWhip() {
+        return isWhip;
+    }
+
+    public Integer getPrice() {
+        return price;
+    }
 }

--- a/jascoffee/src/main/java/com/jascoffee/jascoffee/repository/orderlist/OrderDetailRepository.java
+++ b/jascoffee/src/main/java/com/jascoffee/jascoffee/repository/orderlist/OrderDetailRepository.java
@@ -3,5 +3,8 @@ package com.jascoffee.jascoffee.repository.orderlist;
 import com.jascoffee.jascoffee.entity.orderlist.OrderDetailEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface OrderDetailRepository extends JpaRepository<OrderDetailEntity, Long> {
+    List<OrderDetailEntity> findByOrderDetailID(Long orderDetailID);
 }

--- a/jascoffee/src/main/java/com/jascoffee/jascoffee/repository/orderlist/OrderDetailRepository.java
+++ b/jascoffee/src/main/java/com/jascoffee/jascoffee/repository/orderlist/OrderDetailRepository.java
@@ -1,0 +1,7 @@
+package com.jascoffee.jascoffee.repository.orderlist;
+
+import com.jascoffee.jascoffee.entity.orderlist.OrderDetailEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderDetailRepository extends JpaRepository<OrderDetailEntity, Long> {
+}

--- a/jascoffee/src/main/java/com/jascoffee/jascoffee/service/orderlist/OrderDetailService.java
+++ b/jascoffee/src/main/java/com/jascoffee/jascoffee/service/orderlist/OrderDetailService.java
@@ -1,4 +1,75 @@
 package com.jascoffee.jascoffee.service.orderlist;
 
+import com.jascoffee.jascoffee.dto.orderlist.request.OrderDetailCreateRequest;
+import com.jascoffee.jascoffee.dto.orderlist.response.OrderDetailResponse;
+import com.jascoffee.jascoffee.entity.orderlist.OrderDetailEntity;
+import com.jascoffee.jascoffee.entity.orderlist.OrderListEntity;
+import com.jascoffee.jascoffee.entity.product.Product;
+import com.jascoffee.jascoffee.repository.orderlist.OrderDetailRepository;
+import com.jascoffee.jascoffee.repository.orderlist.OrderListRepository;
+import com.jascoffee.jascoffee.repository.product.ProductRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
 public class OrderDetailService {
+    private final OrderDetailRepository orderDetailRepository;
+    private final OrderListRepository orderListRepository;  // 추가
+    private final ProductRepository productRepository;      // 추가
+
+
+    public OrderDetailService(OrderDetailRepository orderDetailRepository , OrderListRepository orderListRepository, ProductRepository productRepository){
+        this.orderDetailRepository = orderDetailRepository;
+        this.orderListRepository = orderListRepository;
+        this.productRepository = productRepository;
+    }
+
+    public void saveOrderDetail(OrderDetailCreateRequest request) {
+        // OrderDetailEntity 객체 생성
+        OrderDetailEntity detail = new OrderDetailEntity();
+
+        // OrderListEntity와 ProductEntity를 repository에서 가져옴
+        OrderListEntity orderlist = orderListRepository.findById(request.getOrderID())
+                .orElseThrow(() -> new IllegalArgumentException("Invalid Order ID: " + request.getOrderID()));
+        Product product = productRepository.findById(request.getProductID())
+                .orElseThrow(() -> new IllegalArgumentException("Invalid Product ID: " + request.getProductID()));
+
+        // OrderDetailEntity에 값 설정
+        detail.setOrderlist(orderlist);
+        detail.setProduct(product);
+        detail.setIsIce(request.getIsIce());
+        detail.setShot(request.getShot());
+        detail.setPearl(request.getPearl());
+        detail.setMilk(request.getMilk());
+        detail.setSyrup(request.getSyrup());
+        detail.setVanilaSyrup(request.getVanillaSyrup());
+        detail.setHazelnutSyrup(request.getHazelnutSyrup());
+        detail.setIsWhip(request.getIsWhip());
+        detail.setPrice(request.getPrice());
+
+        // 저장
+        orderDetailRepository.save(detail);
+    }
+
+    public List<OrderDetailResponse> getOrderDetails() {
+        return orderDetailRepository.findAll()
+                .stream()
+                .map(OrderDetailResponse::new)
+                .collect(Collectors.toList());
+    }
+//    public List<OrderDetailResponse> getOrderDetail() {
+//        List<OrderDetailEntity> orderdetails = orderDetailRepository.findAll();
+//        return orderdetails.stream()
+//                .map(orderdetail -> new OrderDetailResponse(
+//                        orderdetail.getOrderDetailID(),
+//                        orderdetail.getIsIce()))
+//                .collect(Collectors.toList());
+//    }
+
+
+    public void deleteOrderDetail(Long detailID) {
+        orderDetailRepository.deleteById(detailID);
+    }
 }

--- a/jascoffee/src/main/java/com/jascoffee/jascoffee/service/orderlist/OrderDetailService.java
+++ b/jascoffee/src/main/java/com/jascoffee/jascoffee/service/orderlist/OrderDetailService.java
@@ -59,14 +59,12 @@ public class OrderDetailService {
                 .map(OrderDetailResponse::new)
                 .collect(Collectors.toList());
     }
-//    public List<OrderDetailResponse> getOrderDetail() {
-//        List<OrderDetailEntity> orderdetails = orderDetailRepository.findAll();
-//        return orderdetails.stream()
-//                .map(orderdetail -> new OrderDetailResponse(
-//                        orderdetail.getOrderDetailID(),
-//                        orderdetail.getIsIce()))
-//                .collect(Collectors.toList());
-//    }
+    public List<OrderDetailResponse> getOrderDetailByorderDetailID(Long orderDetailID) {
+        List<OrderDetailEntity> orderdetails = orderDetailRepository.findByOrderDetailID(orderDetailID);
+        return orderdetails.stream()
+                .map(OrderDetailResponse::new)
+                .collect(Collectors.toList());
+    }
 
 
     public void deleteOrderDetail(Long detailID) {


### PR DESCRIPTION
### 전체상품 상세정보 조회 `GET`
![image](https://github.com/user-attachments/assets/f79d0bee-c8c5-4cb6-a366-219f6cce01ad)

### 상품 상세정보 생성 `POST`
![image](https://github.com/user-attachments/assets/c3910f7b-8ea8-46a1-b604-b4b442d324e9)

### 특정 상품 상세정보 조회 `GET`
![image](https://github.com/user-attachments/assets/6aa188e1-7201-46bd-bb00-c7ec4b0f9f08)

----

### 추가내용
1. 주문내역에서 각 user는 본인이 주문한 상품의 상세정보를 확인할 수 있어야 한다.
- 이를 위하여 userID에 맞는 orderlist를 가져온 뒤 orderID에 맞는 특정상품 상세정보 조회를 통해 주문내역을 보여준다.
2. 주문완료시, 각 user의 주문은 orderlist에 저장되며, orderID에 맞게 자동으로 상품상세정보가 저장되도록 한다. 
